### PR TITLE
Helm 3 / Kubernetes 1.16.x (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,66 +18,72 @@ Pegasystems has validated deployments on the following Kubernetes IaaS and PaaS 
 
 # Getting started
 
-This project assumes you have an installation of Kubernetes available and have Helm installed locally.  The following commands will verify your installation.  The exact output may be slightly different, but they should return without error.  
-```console
-$ kubectl get nodes
-NAME                              STATUS    ROLES     AGE       VERSION
-ip-xxx-xxx-xxx-xxx.ec2.internal   Ready     <none>    2d        v1.11.5
-ip-yyy-yyy-yyy-yyy.ec2.internal   Ready     <none>    2d        v1.11.5
-ip-zzz-zzz-zzz-zzz.ec2.internal   Ready     <none>    2d        v1.11.5
+This project assumes you have an installation of Kubernetes available and have Helm installed locally. The following commands will verify your installation. The exact output may be slightly different, but they should return without error.
 
+```bash
 $ helm version
-Client: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.12.2", GitCommit:"7d2b0c73d734f6586ed222a567c5d103fed435be", GitTreeState:"clean"}
+version.BuildInfo{Version:"v3.0.0", GitCommit:"e29ce2a54e96cd02ccfce88bee4f58bb6e2a28b6", GitTreeState:"clean", GoVersion:"go1.13.4"}
 ```
 
-Start by performing a clone (or download) of the latest Charts.
+If this command does not successfully return, install Helm 3 for your operating system.  See [Helm Installation](https://helm.sh/docs/intro/install/) for more information.  If you are running Helm 2.x, you will see both a client and server (tiller) portion returned by the version command.  Some of the commands below will also differ slightly for Helm 2.x.
+
+1. Add the Pega repository to your Helm installation.
 
 ```bash
-git clone https://github.com/pegasystems/pega-helm-charts.git
+$ helm repo add pega https://dl.bintray.com/pegasystems/pega-helm-charts
 ```
 
-## Update dependencies
-
-The Pega charts depends on other charts supplied by third parties.  These are called out in the requirements yaml file for the [pega](charts/pega/requirements.yaml) and [addons](charts/addons/requirements.yaml) charts.  Individual dependencies may or may not be deployed based on the configuration of your values.yaml files.  When you first setup your helm chart, you will need to update your dependencies to pull down these additional charts from their repositories.  For convenience, the required commands are part of the [Makefile](Makefile) and can run with the following command.
+2. Verify the new repository by searching it.
 
 ```bash
-make dependencies
+$ helm search repo pega
+NAME       	CHART VERSION	APP VERSION	DESCRIPTION
+pega/pega  	1.2.0        	           	Pega installation on kubernetes
+pega/addons	1.2.0        	1.0        	A Helm chart for Kubernetes 
 ```
 
-For more information about Helm dependencies, see the [Helm documentation](https://helm.sh/docs/helm/#helm-dependency).
+There are two charts available in this repository - addons and pega.
 
-## Configure and install using the charts
+The addons chart installs a collection of supporting services and tools required for a Pega deployment. The services you will need to deploy will depend on your cloud environment - for example you may need a load balancer on Minikube, but not for EKS. These supporting services are deployed once per Kubernetes environment, regardless of how many Pega Infinity instances are deployed.
 
-There are two charts available in this repository - *addons* and *pega*. 
-
-The addons chart installs a collection of supporting services and tools required for a Pega deployment.  The services you will need to deploy will depend on your cloud environment - for example you may need a load balancer on Minikube, but not for EKS. These supporting services are deployed once per Kubernetes environment, regardless of how many Pega Infinity instances are deployed.
-
-[Instructions to configure the Pega addons](charts/addons/README.md)
-
-To install the addons chart, run the following helm command after configuring your values.yaml file.
+3. Download the values file for pega/pega and pega/addons.
 
 ```bash
-helm install . -n pegaaddons --namespace pegaaddons --values /home/user/my-overridden-values.yaml
+$ helm inspect values pega/pega > pega.yaml
+$ helm inspect values pega/addons > addons.yaml
 ```
 
-After installing the addons, you can deploy Pega. Before installing using the chart, it is a good idea to review the detailed [deployment guide](https://community.pega.com/knowledgebase/articles/deploying-pega-platform-using-kubernetes) to understand how Pega deploys as a distributed system. Running a Helm installation using the pega chart installs a Pega Infinity instance into a specified namespace.  
+4. Edit your values yaml files to specify all required information and customizations for your environment.
 
-[Instructions to configure the Pega chart](charts/pega/README.md)
+* [Instructions to configure the Pega chart](charts/pega/README.md)
+* [Instructions to configure the Pega addons](charts/addons/README.md)
 
-To install the pega chart, run the following helm command after configuring your values.yaml file.
+5. Create namespaces for your Pega deployment and the addons (if applicable for your environment).
 
 ```bash
-helm install . -n mypega --namespace myproject --values /home/user/my-overridden-values.yaml
+$ kubectl create namespace mypega
+$ kubectl create namespace pegaaddons
 ```
 
-To delete this chart, enter:
+6. To install the addons chart, run the following helm command after configuring your values.yaml file (if applicable for your environment). 
 
 ```bash
-helm delete mypega --purge
+$ helm install mypega pega/addons --namespace pegaaddons --values addons.yaml
 ```
 
-Navigate to the project directory and open the values.yaml file.  This is the configuration file that tells Helm what and how to deploy.  For additional documentation covering the different deployment options, see the Pega Community article on [Deploying the Pega Platform by using Kubnernetes](https://community.pega.com/knowledgebase/articles/deploying-pega-platform-using-kubernetes).
+7. Now you can deploy Pega using the Helm chart. Before installing using the chart, it is a good idea to review the detailed [deployment guide](https://community.pega.com/knowledgebase/articles/deploying-pega-platform-using-kubernetes) to understand how Pega deploys as a distributed system. Running a Helm installation using the pega chart installs a Pega Infinity instance into a specified namespace.  
+
+```bash
+$ helm install mypega pega/pega --namespace mypega --values pega.yaml
+```
+
+*If you want to edit the charts and build using your local copy, replace pega/addons or pega/pega with the path to your chart directory.*
+
+8. If you wish to delete your deployment of Pega nodes, enter the following command (this will not delete your database):
+
+```bash
+$ helm delete mypega
+```
 
 # Contributing
 

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -346,7 +346,12 @@ dds:
 
 Use the `pegasearch` section to configure a deployment of ElasticSearch for searching Rules and Work within Pega.  This deployment is used exclusively for Pega search, and is not the same ElasticSearch deployment used by the EFK stack or any other dedicated service such as Pega BI.
 
-Set the `pegasearch.image` location to a registry that can access the Pega search Docker image. The image is [available on DockerHub](https://hub.docker.com/r/pegasystems/search), and you may choose to mirror it in a private Docker repository.
+Parameter   | Description   | Default value
+---         | ---           | ---
+`image`   | Set the `pegasearch.image` location to a registry that can access the Pega search Docker image. The image is [available on DockerHub](https://hub.docker.com/r/pegasystems/search), and you may choose to mirror it in a private Docker repository. | `pegasystems/search:latest`
+`podSecurityContext.runAsUser`   | ElasticSearch defaults to UID 1000.  In some environments where user IDs are restricted, you may configure your own using this parameter. | `1000`
+`set_vm_max_map_count`   | Elasticsearch requires `vm.max_map_count` to be configured to an appropriate value. This may be configured manually on your system and if so, you may bypass this privileged init container. For more information, see the [ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html). | `true`
+`set_data_owner_on_startup`   | Set to true to enable an init container that runs a chown command on the mapped volume at startup to reset the owner of the ES data to the current user. This is needed if a random user is used to run the pod, but also requires privileges to change the ownership of files. | `false`
 
 Example:
 
@@ -354,3 +359,4 @@ Example:
 pegasearch:
   image: "pegasystems/search:8.3"
 ```
+

--- a/charts/pega/charts/pegasearch/templates/pega-search-deployment.yaml
+++ b/charts/pega/charts/pegasearch/templates/pega-search-deployment.yaml
@@ -3,7 +3,7 @@
 # an external search URL which means we need to create one internally.
 {{ if (eq (include "isExternalSearch" .) "true") }} {{ else }}
 kind: StatefulSet
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ template "searchName" . }}
   namespace: {{ .Release.Namespace }}
@@ -25,27 +25,30 @@ spec:
     spec:
       {{ if ne .Values.global.provider "openshift" }}
       securityContext:
-        fsGroup: 1000
+        fsGroup: {{ .Values.podSecurityContext.runAsUser | default 1000 }}
       {{ end }}
       initContainers:
-      {{ if eq .Values.global.provider "openshift" }}
+        # Init containers
+      {{- if and (eq .Values.global.provider "openshift") (eq .Values.set_data_owner_on_startup true) }}
       - name: set-dir-owner
         image: busybox:1.31.0
-        command: ['sh', '-c', 'chown -R 1000:1000 /usr/share/elasticsearch/data']
+        command: ['sh', '-c', 'chown -R {{ .Values.podSecurityContext.runAsUser | default 1000 }}:{{ .Values.podSecurityContext.runAsUser | default 1000 }} /usr/share/elasticsearch/data']
         volumeMounts:
         - name: esstorage
           mountPath: /usr/share/elasticsearch/data
       {{ end }}
+      {{- if .Values.set_vm_max_map_count }}
       - name: set-max-map-count
         image: busybox:1.31.0
         command: ['sysctl', '-w', 'vm.max_map_count=262144']
         securityContext:
           privileged: true
+      {{ end }}
       containers:
       - name: search
         image: {{ .Values.image }}
         securityContext:
-          runAsUser: 1000
+          runAsUser: {{ .Values.podSecurityContext.runAsUser | default 1000 }}
         env:
         - name: HOST_LIST
           value: {{ template "searchName" . }}-transport

--- a/charts/pega/charts/pegasearch/values.yaml
+++ b/charts/pega/charts/pegasearch/values.yaml
@@ -12,6 +12,17 @@ cpuLimit: 1
 memLimit: "4Gi"
 # Enter the volume size limit for each search node (recommended 5Gi).
 volumeSize: "5Gi"
+# Specify a user to run as - Default runAsUser is 1000
+podSecurityContext:
+  runAsUser: 1000
+# Elasticsearch requires vm.max_map_count to be configured to an appropriate value.  This may be
+# configured manually on your system and if so, you may bypass this privileged init container.
+# For more information, see https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html
+set_vm_max_map_count: true
+# Run a chown command on the mapped volume at startup to reset the owner of the ES data to the
+# current user.  This is needed if a random user is used to run the pod, but also requires
+# privileges to change the ownership of files.
+set_data_owner_on_startup: false
 env:
   # IMPORTANT: https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#minimum_master_nodes
   # To prevent data loss, it is vital to configure the discovery.zen.minimum_master_nodes setting so that each master-eligible

--- a/charts/pega/templates/_pega-openshift-ingress.tpl
+++ b/charts/pega/templates/_pega-openshift-ingress.tpl
@@ -12,7 +12,7 @@ metadata:
     haproxy.router.openshift.io/balance: roundrobin
 spec:
   # Host on which you can reach mentioned service.
-  host: {{ .node.domain }}
+  host: {{ .node.service.domain }}
   to:
     kind: Service
     # Name of the service associated with the route

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -14,8 +14,10 @@ data:
   JDBC_CLASS: {{ .Values.global.jdbc.driverClass }}
   # URI that the JDBC driver can be downloaded from
   JDBC_DRIVER_URI: {{ .Values.global.jdbc.driverUri }}
+{{- if .Values.global.jdbc.connectionProperties }}
   # The connection properties that will be sent to our JDBC driver when establishing new connections
   JDBC_CONNECTION_PROPERTIES: {{ .Values.global.jdbc.connectionProperties }}
+{{- end }}
   # Rules schema of the Pega installation
 {{ if (eq (include "performUpgradeAndDeployment" .) "true") }}
   RULES_SCHEMA: {{ .Values.installer.upgrade.targetRulesSchema }}
@@ -24,8 +26,10 @@ data:
 {{ end }}
   # Data schema of the Pega installation
   DATA_SCHEMA: {{ .Values.global.jdbc.dataSchema }}
+{{- if .Values.global.jdbc.customerDataSchema }}
   # CustomerData schema of the Pega installation
   CUSTOMERDATA_SCHEMA: {{ .Values.global.jdbc.customerDataSchema }}
+{{- end }}
   # URL to connect to Elastic Search
   PEGA_SEARCH_URL: {{ .Values.pegasearch.externalURL }}
   # Whether to enable connecting to a cassandra cluster.  "true" for enabled, "false for disabled"

--- a/charts/pega/templates/pega-tier-deployment.yaml
+++ b/charts/pega/templates/pega-tier-deployment.yaml
@@ -3,10 +3,10 @@
 {{ range $index, $dep := .Values.global.tier}}
 {{ if ($dep.volumeClaimTemplate) }}
 {{ $kindName = "StatefulSet" }}
-{{ $apiVer = "apps/v1beta2" }}
+{{ $apiVer = "apps/v1" }}
 {{ else }}
 {{ $kindName = "Deployment" }}
-{{ $apiVer = "extensions/v1beta1" }}
+{{ $apiVer = "apps/v1" }}
 {{ end }}
 
 {{ $containerWaitList := list  }}


### PR DESCRIPTION
* Updates for Helm 3 #34 .
* Readme now references bintray repo and the *getting started* section no longer requires a repo clone.
* API references updated to support Kubernetes 1.16.x. #27 
* Fixed host name mapping for OpenShift's route
* Converted several sections to be parameterized
  * Added pegasearch.set_vm_max_map_count - Elasticsearch requires vm.max_map_count to be configured to an appropriate value.  This may be configured manually on your system and if so, you may bypass this privileged init container. For more information, see the [ElasticSearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html).  This value defaults to **true**.
  * Added pegasearch.runAsUser - Specify a user to run as.  This is helpful in locked down environments. Default runAsUser is **1000**.
  * Added pegasearch.set_data_owner_on_startup - Set to true to enable an init container that runs a chown command on the mapped volume at startup to reset the owner of the ES data to the current user.  This is needed if a random user is used to run the pod, but also requires privileges to change the ownership of files.  This value defaults to **true**.